### PR TITLE
feat: improve gazette delivery and access

### DIFF
--- a/docs/gap_analysis.md
+++ b/docs/gap_analysis.md
@@ -44,3 +44,7 @@
 - **Design intent:** Generate press and scholar reactions through persona-driven LLM prompts with batching and moderation safeguards.【F:docs/HLD.md†L318-L369】
 - **Implementation status:** Scholar reactions and press copy remain templated string substitutions without any LLM calls or safety layers.【F:great_work/service.py†L553-L569】【F:great_work/press.py†L14-L122】
 - **Gap:** Introduce the planned persona prompt pipeline, batching strategies, and moderation checks to reach the intended narrative richness.【F:docs/HLD.md†L318-L369】
+
+## Remediation Progress Snapshot
+- **Gazette delivery:** The scheduler now accepts an optional publisher so digest and symposium artefacts can be routed directly to Discord or other channels instead of relying solely on logs.【F:great_work/scheduler.py†L15-L64】
+- **Public archive access:** Players can browse recent Gazette headlines through the `/gazette` slash command, which surfaces stored press releases via the `GameService` archive helpers.【F:great_work/discord_bot.py†L118-L156】【F:great_work/service.py†L473-L501】

--- a/great_work/discord_bot.py
+++ b/great_work/discord_bot.py
@@ -161,6 +161,21 @@ def build_bot(db_path: Path, intents: Optional[discord.Intents] = None) -> comma
             lines.append("No active cooldowns.")
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
+    @app_commands.command(name="gazette", description="Show recent Gazette headlines")
+    async def gazette(interaction: discord.Interaction, limit: int = 5) -> None:
+        if limit <= 0 or limit > 20:
+            await interaction.response.send_message("Limit must be between 1 and 20", ephemeral=True)
+            return
+        records = service.export_press_archive(limit=limit)
+        if not records:
+            await interaction.response.send_message("No Gazette entries recorded yet.", ephemeral=True)
+            return
+        lines = ["Recent Gazette entries:"]
+        for record in records:
+            timestamp = record.timestamp.strftime("%Y-%m-%d %H:%M")
+            lines.append(f" - {timestamp} | {record.release.headline}")
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
     @app_commands.command(name="export_log", description="Export recent events and press")
     async def export_log(interaction: discord.Interaction, limit: int = 10) -> None:
         if limit <= 0 or limit > 50:
@@ -180,6 +195,7 @@ def build_bot(db_path: Path, intents: Optional[discord.Intents] = None) -> comma
     bot.tree.add_command(resolve_expeditions)
     bot.tree.add_command(recruit)
     bot.tree.add_command(status)
+    bot.tree.add_command(gazette)
     bot.tree.add_command(export_log)
     return bot
 


### PR DESCRIPTION
## Summary
- allow the Gazette scheduler to stream press releases to an injected publisher so digests can reach Discord or other surfaces
- expose a /gazette slash command in the Discord bot for reviewing recent press headlines stored in the archive
- document the new delivery and archive access capabilities in the gap analysis remediation snapshot

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbd3a691d0832389d6ca2c9e5ff162